### PR TITLE
优化导航与文章索引交互，统一主题组件和编辑器配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ node_modules/
 .pnpm-store/
 docs/.vitepress/dist/
 docs/.vitepress/cache/
-.vscode/
 .DS_Store
 *.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.formatOnSave": true,
+  "editor.formatOnType": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always"
+  },
+  "eslint.format.enable": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "vue",
+    "json",
+    "jsonc",
+    "yaml",
+    "css"
+  ],
+  "[markdown]": {
+    "editor.defaultFormatter": "yzhang.markdown-all-in-one"
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -23,6 +23,8 @@ export default defineConfig({
 	lastUpdated: true,
 	rewrites: source => rewrites.get(source) || source,
 	head: [
+		['link', { rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/inter-ui@4.1.1/inter-variable.css' }],
+		['link', { rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/inter-ui@4.1.1/inter.css' }],
 		['link', { 'rel': 'icon', 'type': 'image/svg+xml', 'href': '/favicon-light.svg', 'media': '(prefers-color-scheme: light)', 'data-wiki-icon': '' }],
 		['link', { 'rel': 'icon', 'type': 'image/svg+xml', 'href': '/favicon-dark.svg', 'media': '(prefers-color-scheme: dark)', 'data-wiki-icon': '' }],
 	],
@@ -69,13 +71,20 @@ export default defineConfig({
 		returnToTopLabel: '返回顶部',
 		outline: { level: [2, 3], label: '本页目录' },
 		docFooter: { prev: '上一篇', next: '下一篇' },
-		editLink: { pattern: 'https://github.com/NCEPUwiki/NCEPUwiki/blame/main/docs/:path', text: '在 GitHub 上查看此页' },
+		editLink: { pattern: 'https://github.com/NCEPUwiki/NCEPUwiki/blame/main/docs/:path', text: '源代码' },
 		lastUpdated: { text: '最后更新于', formatOptions: { dateStyle: 'medium' } },
 		footer: { message: '由华电学生共同维护的非官方校园知识库', copyright: `© 2025–${new Date().getFullYear()} NCEPUwiki-Group · MIT License` },
 	},
 	vite: { plugins: [markmapPlugin({ containerHeight: 500 })], resolve: { alias: { '@': fileURLToPath(new URL('./', import.meta.url)) } } },
 	markdown: {
-		config: md => cardlist(md),
+		config: (md) => {
+			cardlist(md)
+			const headingClose = md.renderer.rules.heading_close
+			md.renderer.rules.heading_close = (tokens, index, options, env, self) => {
+				const decoration = tokens[index].tag === 'h2' ? '<span class="heading-wordmark" aria-hidden="true"></span>' : ''
+				return decoration + (headingClose?.(tokens, index, options, env, self) ?? self.renderToken(tokens, index, options))
+			}
+		},
 		languageAlias: { gitignore: 'text' },
 		math: true,
 		container: { tipLabel: '提示', warningLabel: '注意', dangerLabel: '警告', infoLabel: '信息', detailsLabel: '详细信息' },
@@ -85,7 +94,7 @@ export default defineConfig({
 		if (article) {
 			page.title = article.title
 			page.lastUpdated = article.updatedTime || undefined
-			Object.assign(page.frontmatter, { title: article.title, categories: article.categories, tags: article.tags, articleHeader: !article.hasHeading, empty: article.empty })
+			Object.assign(page.frontmatter, { title: article.title, breadcrumbs: article.folders, categories: article.categories, tags: article.tags, articleHeader: !article.hasHeading, empty: article.empty })
 		}
 	},
 })

--- a/docs/.vitepress/theme/chips.ts
+++ b/docs/.vitepress/theme/chips.ts
@@ -1,0 +1,15 @@
+import type { TaxonomyCount } from '../types'
+
+export interface ChipItem {
+	text: string
+	value?: string
+	href?: string
+	count?: number
+}
+
+export function tagChips(tags: (string | TaxonomyCount)[]): ChipItem[] {
+	return tags.map((tag) => {
+		const name = typeof tag === 'string' ? tag : tag.name
+		return { text: `# ${name}`, href: `/tags/?tag=${encodeURIComponent(name)}`, count: typeof tag === 'string' ? undefined : tag.count }
+	})
+}

--- a/docs/.vitepress/theme/components/ArticleByline.vue
+++ b/docs/.vitepress/theme/components/ArticleByline.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import timeIcon from '@iconify-icons/ri/time-line'
+import userIcon from '@iconify-icons/ri/user-line'
+import { Icon } from '@iconify/vue'
+
+defineProps<{ date?: string, author?: string }>()
+</script>
+
+<template>
+<div v-if="date || author" class="index-byline">
+	<span v-if="date" class="article-date"><Icon :icon="timeIcon" aria-hidden="true" /><time :datetime="date">{{ date }}</time></span>
+	<span v-if="author" class="article-author"><Icon :icon="userIcon" aria-hidden="true" />{{ author }}</span>
+</div>
+</template>

--- a/docs/.vitepress/theme/components/ArticleIndex.vue
+++ b/docs/.vitepress/theme/components/ArticleIndex.vue
@@ -5,6 +5,9 @@ import listIcon from '@iconify-icons/ri/list-check'
 import { Icon } from '@iconify/vue'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { data } from '../catalog.data'
+import { tagChips } from '../chips'
+import ArticleByline from './ArticleByline.vue'
+import WikiChips from './WikiChips.vue'
 
 const props = withDefaults(defineProps<{ mode?: IndexMode, category?: string }>(), { mode: 'archives', category: '' })
 const selected = ref(props.category)
@@ -54,17 +57,24 @@ const groups = computed(() => {
 
 <template>
 <div class="article-index">
-	<div v-if="choices.length && !category" class="chips filters" aria-label="筛选文章">
-		<button :aria-pressed="!selected" @click="updateQuery('')">
-			全部 {{ data.articles.length }}
-		</button>
-		<button v-for="choice in choices" :key="choice.name" :aria-pressed="selected === choice.name" @click="updateQuery(choice.name)">
-			{{ mode === 'tags' ? '# ' : '' }}{{ choice.name }} <span>{{ choice.count }}</span>
-		</button>
+	<WikiChips
+		v-if="choices.length && !category"
+		:items="[{ text: '全部', value: '', count: data.articles.length }, ...choices.map(choice => ({ text: `${mode === 'tags' ? '# ' : ''}${choice.name}`, value: choice.name, count: choice.count }))]"
+		:selected="selected"
+		label="筛选文章"
+		@select="updateQuery"
+	/>
+	<div class="index-controls">
+		<input v-model="query" type="search" aria-label="筛选标题、分类或标签" placeholder="筛选标题、分类或标签…" @input="updateQuery(selected, true)">
+		<div class="layout-switch" aria-label="文章展示形式">
+			<button :aria-pressed="view === 'cards'" aria-label="卡片视图" @click="view = 'cards'">
+				<Icon :icon="gridIcon" />
+			</button>
+			<button :aria-pressed="view === 'list'" aria-label="列表视图" @click="view = 'list'">
+				<Icon :icon="listIcon" />
+			</button>
+		</div>
 	</div>
-	<label class="index-search">筛选标题、分类或标签
-		<input v-model="query" type="search" placeholder="输入关键词…" @input="updateQuery(selected, true)">
-	</label>
 
 	<p v-if="!articles.length" class="empty-state">
 		没有找到符合条件的文章。<button @click="query = ''; updateQuery('')">
@@ -73,21 +83,15 @@ const groups = computed(() => {
 	</p>
 	<section v-for="[name, list] in groups" :key="name">
 		<div class="index-section-heading">
-			<h2>{{ name }} <span class="section-count">{{ list.length }}</span></h2><div class="layout-switch" :aria-label="`${name}展示形式`">
-				<button :aria-pressed="view === 'cards'" aria-label="卡片视图" @click="view = 'cards'">
-					<Icon :icon="gridIcon" />
-				</button><button :aria-pressed="view === 'list'" aria-label="列表视图" @click="view = 'list'">
-					<Icon :icon="listIcon" />
-				</button>
-			</div>
+			<h2>{{ name }} <span class="section-count">{{ list.length }}</span></h2>
 		</div>
 		<ul class="article-list" :class="{ 'article-cards': view === 'cards' }">
 			<li v-for="article in list" :key="article.url">
-				<a :href="article.url">{{ article.title }}</a>
-				<time v-if="article.updated" :datetime="article.updated">{{ article.updated }}</time>
-				<div class="chips tags">
-					<a v-for="tag in article.tags" :key="tag" :href="`/tags/?tag=${encodeURIComponent(tag)}`"># {{ tag }}</a>
+				<div class="index-item-content">
+					<a class="article-title" :href="article.url">{{ article.title }}</a>
+					<WikiChips :items="tagChips(article.tags)" class="tags" label="文章标签" />
 				</div>
+				<ArticleByline :date="article.updated" :author="article.author" />
 			</li>
 		</ul>
 	</section>

--- a/docs/.vitepress/theme/components/ArticleMeta.vue
+++ b/docs/.vitepress/theme/components/ArticleMeta.vue
@@ -1,25 +1,44 @@
 <script setup lang="ts">
+import timeIcon from '@iconify-icons/ri/time-line'
+import userIcon from '@iconify-icons/ri/user-line'
+import { Icon } from '@iconify/vue'
 import { useData } from 'vitepress'
+import { computed } from 'vue'
+import { tagChips } from '../chips'
+import WikiChips from './WikiChips.vue'
 
-const { frontmatter: fm } = useData()
+const { frontmatter: fm, page } = useData()
+const author = computed(() => typeof fm.value.author === 'string' ? fm.value.author : fm.value.author?.name)
+const authorUrl = computed(() => typeof fm.value.author === 'object' ? fm.value.author?.url || fm.value.author?.link : undefined)
+const date = computed(() => page.value.lastUpdated ? new Date(page.value.lastUpdated).toISOString().slice(0, 10) : '')
 </script>
 
 <template>
 <div v-if="fm.categories?.length || fm.articleHeader" class="article-meta vp-doc">
-	<div class="chips" aria-label="文章分类">
-		<a v-for="category in fm.categories" :key="category" :href="`/categories/?category=${encodeURIComponent(category)}`">{{ category }}</a>
-	</div>
+	<nav v-if="fm.breadcrumbs?.length" class="article-breadcrumbs" aria-label="文章所在目录">
+		<ol>
+			<li v-for="category in fm.breadcrumbs" :key="category">
+				<a :href="`/categories/?category=${encodeURIComponent(category)}`">{{ category }}</a>
+			</li>
+		</ol>
+	</nav>
 	<h1 v-if="fm.articleHeader" id="article-title">
 		{{ fm.title }}
 	</h1>
-	<div class="chips tags" aria-label="文章标签">
-		<a v-for="tag in fm.tags" :key="tag" :href="`/tags/?tag=${encodeURIComponent(tag)}`"># {{ tag }}</a>
+	<div v-if="author || date" class="article-byline">
+		<span v-if="author" class="article-author">
+			<Icon :icon="userIcon" aria-hidden="true" />
+			<a v-if="authorUrl" :href="authorUrl" target="_blank" rel="noopener noreferrer">{{ author }}</a>
+			<span v-else>{{ author }}</span>
+		</span>
+		<span v-if="date" class="article-date">
+			<Icon :icon="timeIcon" aria-hidden="true" />
+			<time :datetime="date">{{ date }}</time>
+		</span>
 	</div>
-	<p v-if="fm.author" class="muted">
-		作者：{{ typeof fm.author === 'string' ? fm.author : fm.author.name }}
-	</p>
+	<WikiChips :items="tagChips(fm.tags || [])" class="tags" label="文章标签" />
 	<p v-if="fm.empty" class="empty-state">
-		这篇条目正在等待补充，欢迎点击页末编辑链接参与共建。
+		这篇条目正在等待补充，欢迎通过页末源代码链接参与共建。
 	</p>
 </div>
 </template>

--- a/docs/.vitepress/theme/components/WidePage.vue
+++ b/docs/.vitepress/theme/components/WidePage.vue
@@ -12,7 +12,7 @@ const { page } = useData()
 		<Content />
 	</div>
 	<footer class="wide-footer">
-		<a :href="`https://github.com/NCEPUwiki/NCEPUwiki/edit/main/docs/${page.filePath}`">在 GitHub 上编辑此页</a>
+		<a :href="`https://github.com/NCEPUwiki/NCEPUwiki/blame/main/docs/${page.filePath}`">源代码</a>
 		<time v-if="page.lastUpdated" :datetime="new Date(page.lastUpdated).toISOString()">内容日期：{{ new Date(page.lastUpdated).toISOString().slice(0, 10) }}</time>
 	</footer>
 </main>

--- a/docs/.vitepress/theme/components/WikiChips.vue
+++ b/docs/.vitepress/theme/components/WikiChips.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { ChipItem } from '../chips'
+
+defineProps<{ items: ChipItem[], selected?: string, label?: string }>()
+defineEmits<{ select: [value: string] }>()
+</script>
+
+<template>
+<div v-if="items.length" class="chips" :aria-label="label">
+	<component
+		:is="item.href ? 'a' : 'button'"
+		v-for="item in items"
+		:key="item.value ?? item.text"
+		class="chip"
+		:href="item.href"
+		:type="item.href ? undefined : 'button'"
+		:aria-pressed="item.href ? undefined : selected === item.value"
+		@click="!item.href && $emit('select', item.value ?? item.text)"
+	>
+		{{ item.text }}<span v-if="item.count !== undefined" class="chip-count">{{ item.count }}</span>
+	</component>
+</div>
+</template>

--- a/docs/.vitepress/theme/components/WikiHome.vue
+++ b/docs/.vitepress/theme/components/WikiHome.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { data } from '../catalog.data'
+import { tagChips } from '../chips'
+import ArticleByline from './ArticleByline.vue'
 import DirectoryTrigger from './DirectoryTrigger.vue'
 import QrCode from './QrCode.vue'
 import SiteIcon from './SiteIcon.vue'
+import WikiChips from './WikiChips.vue'
 
 const topics = [
 	['新生入学', '从录取通知书到校园第一天'],
@@ -74,16 +77,15 @@ const latest = [...data.articles].sort((a, b) => b.updatedTime - a.updatedTime |
 				</div>
 				<ol class="recent-list">
 					<li v-for="article in latest" :key="article.url">
-						<a :href="article.url">{{ article.title }}</a><time :datetime="article.updated">{{ article.updated }}</time>
+						<a :href="article.url">{{ article.title }}</a>
+						<ArticleByline :date="article.updated" :author="article.author" />
 					</li>
 				</ol>
 			</section>
 			<section>
 				<div class="section-heading">
 					<h2>热门标签</h2><a href="/tags/">全部 →</a>
-				</div><div class="chips">
-					<a v-for="tag in data.tags.slice(0, 12)" :key="tag.name" :href="`/tags/?tag=${encodeURIComponent(tag.name)}`"># {{ tag.name }} <span>{{ tag.count }}</span></a>
-				</div>
+				</div><WikiChips :items="tagChips(data.tags.slice(0, 12))" label="热门标签" />
 			</section>
 			<section>
 				<h2>联系我们</h2><p>聊天交流 QQ 群 <strong>417695180</strong><br>编辑贡献 QQ 群 <strong>1049790737</strong></p><a href="mailto:1361942776@qq.com">1361942776@qq.com ↗</a><details class="qr-details">

--- a/docs/.vitepress/theme/components/WikiLayout.vue
+++ b/docs/.vitepress/theme/components/WikiLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useData } from 'vitepress'
-import DefaultTheme from 'vitepress/theme'
+import DefaultTheme from 'vitepress/theme-without-fonts'
 import { onMounted, watch } from 'vue'
 import ArticleMeta from './ArticleMeta.vue'
 import DirectoryModal from './DirectoryModal.vue'

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,6 @@
 import type { Theme } from 'vitepress'
 import type { Component } from 'vue'
-import DefaultTheme from 'vitepress/theme'
+import DefaultTheme from 'vitepress/theme-without-fonts'
 import { defineAsyncComponent } from 'vue'
 import ArticleIndex from './components/ArticleIndex.vue'
 import CopyContact from './components/CopyContact.vue'

--- a/docs/.vitepress/theme/styles/article.css
+++ b/docs/.vitepress/theme/styles/article.css
@@ -1,16 +1,27 @@
-.article-meta { margin-bottom: 24px; }
-.article-meta h1 { margin: 22px 0 16px; }
-.article-meta .tags { margin-top: 12px; }
+.article-meta {
+	margin-bottom: 24px;
+}
+
+.article-meta h1 {
+	margin: 22px 0 16px;
+}
+
+.article-meta .tags {
+	margin-top: 12px;
+}
+
 .muted {
 	font-size: 13px;
 	color: var(--vp-c-text-2);
 }
+
 .index-search {
 	display: grid;
 	gap: 8px;
 	margin: 24px 0 12px;
 	font-size: 13px;
 }
+
 .index-search input {
 	width: 100%;
 	padding: 10px 14px;
@@ -20,52 +31,69 @@
 	font: inherit;
 	color: var(--vp-c-text-1);
 }
+
 .index-search input:focus {
 	outline: 2px solid var(--vp-c-brand-1);
 	outline-offset: 2px;
 }
+
 .vp-doc .article-list {
+	margin: 12px -16px;
 	padding: 0;
 	list-style: none;
 }
+
 .article-list li {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: baseline;
 	gap: 6px;
-	padding: 8px 0;
+	/* eslint-disable-next-line css/no-important */
+	margin-top: 0 !important;
+	padding: 16px;
 	border-bottom: 1px solid var(--vp-c-divider);
 }
-.article-list li > a {
+
+.article-list .article-title {
 	flex: 1;
 	min-width: 180px;
 	text-decoration: none;
 }
+
 .article-list time {
 	font-size: 12px;
 	color: var(--vp-c-text-2);
 }
-.article-list .chips { flex-basis: 100%; }
-.tags a {
-	border: none;
-	background: var(--vp-c-bg-soft);
+
+.article-list .chips {
+	flex-basis: 100%;
 }
+
 .empty-state {
 	padding: 20px;
 	border-radius: 8px;
 	background: var(--vp-c-bg-soft);
 }
+
 .empty-state button {
 	text-decoration: underline;
 	color: var(--vp-c-brand-1);
 }
-.directory-tree summary { font-weight: 600; }
+
+.directory-tree summary {
+	font-weight: 600;
+}
+
 .vp-doc .directory-tree {
 	padding-inline-start: 20px;
 	border-inline-start: 1px solid var(--vp-c-divider);
 	list-style: none;
 }
-.directory-tree li { margin: 10px 0; }
+
+.directory-tree li {
+	margin: 10px 0;
+}
+
 .wiki-download {
 	padding: 6px 14px;
 	border: 1px solid var(--vp-c-divider);
@@ -73,17 +101,23 @@
 	font: inherit;
 	cursor: pointer;
 }
+
 .wiki-download:disabled {
 	opacity: 0.6;
 	cursor: wait;
 }
-.vp-doc img { border-radius: var(--wiki-radius-small); }
+
+.vp-doc img {
+	border-radius: var(--wiki-radius-small);
+}
+
 .site-icon {
 	width: 28px;
 	height: 28px;
 	margin-right: 8px;
 	color: var(--vp-c-brand-1);
 }
+
 .directory-trigger {
 	display: inline-flex;
 	align-items: center;
@@ -93,6 +127,7 @@
 	line-height: 24px;
 	cursor: pointer;
 }
+
 .VPNavBar .directory-trigger {
 	display: inline-flex;
 	align-items: center;
@@ -101,6 +136,7 @@
 	padding: 0 12px;
 	line-height: 24px;
 }
+
 .directory-modal {
 	width: min(960px, calc(100vw - 24px));
 	max-height: 85dvh;
@@ -111,50 +147,65 @@
 	background: var(--vp-c-bg);
 	color: var(--vp-c-text-1);
 }
-.directory-modal::backdrop { background: #0008; }
-.directory-panel { padding: 0 20px 20px; }
+
+.directory-modal::backdrop {
+	background: #0008;
+}
+
+.directory-panel {
+	padding: 0 20px 20px;
+}
+
 .directory-panel header {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: 12px;
 }
+
 .directory-panel h2 {
 	font-size: 20px;
 	font-weight: 600;
 }
+
 .directory-panel > .directory-tree {
 	columns: 2;
 	column-gap: 24px;
 }
-.directory-panel > .directory-tree > li { break-inside: avoid; }
+
+.directory-panel > .directory-tree > li {
+	break-inside: avoid;
+}
+
 .directory-panel .directory-tree {
 	padding-left: 16px;
 	font-size: 14px;
 }
-.directory-panel .directory-tree li { margin: 6px 0; }
+
+.directory-panel .directory-tree li {
+	margin: 6px 0;
+}
+
 .vp-doc .article-cards {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
 	gap: 10px;
 }
+
 .vp-doc .article-cards li {
 	align-content: start;
 	margin: 0;
-	padding: 10px 12px;
+	padding: 16px;
 	border: 1px solid var(--vp-c-divider);
 	border-radius: 8px;
 }
-.article-cards li > a {
+
+.article-cards .article-title {
 	flex-basis: 100%;
 	min-width: 0;
 	font-size: 14px;
 }
-.article-list .chips { gap: 4px; }
-.article-list .chips a {
-	padding: 1px 5px;
-	font-size: 11px;
-}
+
 .wiki-qr {
 	display: inline-block;
 	max-width: 100%;
@@ -162,13 +213,20 @@
 	line-height: 0;
 	vertical-align: middle;
 }
+
 .wiki-qr svg {
 	width: 100%;
 	height: auto;
 }
+
 @media (max-width: 600px) {
-	.directory-panel > .directory-tree { columns: 1; }
-	.vp-doc .article-cards { grid-template-columns: 1fr; }
+	.directory-panel > .directory-tree {
+		columns: 1;
+	}
+
+	.vp-doc .article-cards {
+		grid-template-columns: 1fr;
+	}
 }
 
 .vp-doc .markmap-container table {
@@ -177,6 +235,228 @@
 	width: max-content;
 	margin: 0;
 }
+
 .vp-doc .markmap-container :is(th, td) {
 	white-space: nowrap;
+}
+
+.article-list:not(.article-cards) > li:last-child {
+	border-bottom: 0;
+}
+
+.article-cards > li {
+	position: relative;
+	isolation: isolate;
+}
+
+.article-cards > li .article-title::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	border-radius: inherit;
+}
+
+.article-cards .tags a {
+	position: relative;
+	z-index: 1;
+}
+
+.article-cards > li:has(.article-title:focus-visible) {
+	outline: 2px solid var(--vp-c-brand-1);
+	outline-offset: 2px;
+}
+
+.article-cards > li .article-title:focus-visible {
+	outline: none;
+}
+
+.article-breadcrumbs ol {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 4px 8px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.article-breadcrumbs li + li {
+	margin-top: 0;
+}
+
+.article-breadcrumbs li + li::before {
+	content: "/" / "";
+	margin-inline-end: 8px;
+	color: var(--vp-c-text-3);
+}
+
+.article-breadcrumbs a {
+	font-size: 12px;
+	text-decoration: none;
+	color: var(--vp-c-text-2);
+}
+
+.article-byline,
+.article-author,
+.article-date {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 3px;
+}
+
+.article-byline {
+	gap: 8px 16px;
+	margin-block: 12px;
+	font-size: 12px;
+	color: var(--vp-c-text-2);
+}
+
+.article-byline svg {
+	width: 14px;
+	height: 14px;
+}
+
+.article-byline a {
+	text-decoration: none;
+	color: inherit;
+}
+
+/* Keep heading decorations within article prose, away from cards and diagrams. */
+.vp-doc > div {
+	counter-reset: article-section;
+}
+
+.vp-doc > div > h2 {
+	position: relative;
+	counter-increment: article-section;
+	isolation: isolate;
+}
+
+.vp-doc > div > h2::before {
+	content: counter(article-section) / "";
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline-start: -0.35em;
+	font-size: 3.5rem;
+	font-weight: 700;
+	line-height: 1;
+	color: transparent;
+	pointer-events: none;
+	z-index: -1;
+	-webkit-text-stroke: 1px var(--vp-c-divider);
+}
+
+.heading-wordmark {
+	display: none;
+}
+
+.vp-doc > div > h2 > .heading-wordmark {
+	display: inline-block;
+	float: inline-end;
+	opacity: 0.2;
+	margin-inline-start: 12px;
+	font-size: 18px;
+	font-weight: 600;
+	letter-spacing: -0.05em;
+	pointer-events: none;
+	user-select: none;
+}
+
+.heading-wordmark::before {
+	content: "NCEPU";
+}
+
+.heading-wordmark::after {
+	content: "Wiki";
+	color: var(--vp-c-brand-1);
+}
+
+.vp-doc > div > h3::before {
+	content: "";
+	display: inline-block;
+	width: 1em;
+	height: 1em;
+	margin-inline-end: 0.35em;
+	background: var(--vp-c-brand-1);
+	mask: url("/favicon-light.svg") center / contain no-repeat;
+	vertical-align: -0.1em;
+}
+
+.index-controls {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-block: 24px 12px;
+}
+
+.index-controls input {
+	flex: 1;
+	min-width: 0;
+	padding: 10px 14px;
+	border: 1px solid var(--vp-c-divider);
+	border-radius: 8px;
+	background: var(--vp-c-bg-soft);
+	font: inherit;
+	font-size: 13px;
+	color: var(--vp-c-text-1);
+}
+
+.index-controls .layout-switch {
+	flex-shrink: 0;
+}
+
+.index-byline {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 4px;
+	font-size: 12px;
+	color: var(--vp-c-text-2);
+}
+
+.article-cards .index-byline {
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 4px 12px;
+}
+
+.index-byline svg {
+	width: 14px;
+	height: 14px;
+}
+
+.index-item-content {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 6px;
+	min-width: 0;
+}
+
+.article-list:not(.article-cards) > li {
+	flex-wrap: nowrap;
+	gap: 16px;
+}
+
+.article-list:not(.article-cards) .article-title {
+	min-width: 0;
+}
+
+.article-list:not(.article-cards) .index-byline {
+	flex: 0 0 auto;
+	max-width: 45%;
+}
+
+.article-cards .index-item-content {
+	display: contents;
+}
+
+.article-cards .index-byline {
+	order: 1;
+}
+
+.article-cards .chips {
+	order: 2;
 }

--- a/docs/.vitepress/theme/styles/base.css
+++ b/docs/.vitepress/theme/styles/base.css
@@ -1,26 +1,33 @@
 .chips {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8px;
+	gap: 0 4px;
+	margin: -2px -4px;
 }
-.chips a, .chips button {
+
+.chips .chip {
 	display: inline-flex;
 	align-items: center;
-	gap: 7px;
-	padding: 4px 9px;
-	border: 1px solid var(--vp-c-divider);
+	gap: 6px;
+	position: relative;
+	padding: 2px 4px;
+	border: 0;
 	border-radius: var(--wiki-radius-small);
+	background: transparent;
 	font-size: 12px;
-	line-height: 1.6;
+	font-weight: 400;
 	text-decoration: none;
 	color: var(--vp-c-text-2);
+	transition: color var(--wiki-duration), background var(--wiki-duration);
 }
-.chips a:hover, .chips button:hover, .chips button[aria-pressed="true"] {
-	border-color: var(--vp-c-brand-1);
+
+.chips .chip:hover,
+.chips .chip[aria-pressed="true"] {
 	background: var(--vp-c-brand-soft);
 	color: var(--vp-c-brand-1);
 }
-.chips span {
+
+.chip-count {
 	opacity: 0.65;
 	font-size: 11px;
 }
@@ -30,15 +37,33 @@
 	text-autospace: normal;
 	scrollbar-color: var(--vp-c-text-3) transparent;
 }
-code, pre { text-autospace: no-autospace; }
-::selection { background-color: var(--vp-c-brand-soft); }
+
+code,
+pre {
+	text-autospace: no-autospace;
+}
+
+::selection {
+	background-color: var(--vp-c-brand-soft);
+}
+
 :where(a, button, summary, input):focus-visible {
 	outline: 2px solid var(--vp-c-brand-1);
 	outline-offset: 4px;
 }
+
 @media (prefers-reduced-motion: reduce) {
 	:root {
 		--wiki-duration: 0s;
 		scroll-behavior: auto;
 	}
+}
+
+.chips:empty {
+	display: none;
+}
+
+/* The search dialog already highlights the complete search bar on focus. */
+#localsearch-input:focus-visible {
+	outline: none;
 }

--- a/docs/.vitepress/theme/styles/cards.css
+++ b/docs/.vitepress/theme/styles/cards.css
@@ -2,7 +2,7 @@
 	display: flex;
 	justify-content: flex-start;
 	width: 100%;
-	margin-bottom: 12px;
+	margin-bottom: 0;
 	padding: 10px 0;
 	border-bottom: 1px solid var(--vp-c-divider);
 }
@@ -311,7 +311,7 @@
 }
 
 .wiki-wide .article-list.article-cards li {
-	padding: 14px 16px;
+	padding: 12px 16px;
 	border: 1px solid transparent;
 	background: var(--vp-c-bg-soft);
 }
@@ -426,4 +426,45 @@
 .layout-switch svg {
 	width: 18px;
 	height: 18px;
+}
+
+/* Nested counters follow the generated sidebar tree, including collapsed groups. */
+.VPSidebar .nav,
+.VPSidebar .items {
+	counter-reset: sidebar;
+}
+
+.VPSidebarItem {
+	counter-increment: sidebar;
+}
+
+.VPSidebarItem > .item::before {
+	content: counter(sidebar) / "";
+	flex-shrink: 0;
+	align-self: baseline;
+	width: 0;
+	padding-block: 4px;
+	font-size: 10px;
+	letter-spacing: -0.05em;
+	line-height: 24px;
+	white-space: nowrap;
+	text-align: right;
+	color: var(--vp-c-text-3);
+	transform: translateX(-10px);
+}
+
+.VPSidebarItem.is-active > .item::before {
+	color: var(--vp-c-brand-1);
+}
+
+.VPSidebarItem.level-0 > .item::before {
+	content: counter(sidebar, cjk-ideographic) / "";
+}
+
+.VPSidebarItem:is(.level-2, .level-5) > .item::before {
+	content: counter(sidebar, lower-alpha) / "";
+}
+
+.VPSidebarItem.level-3 > .item::before {
+	content: counter(sidebar, lower-roman) / "";
 }

--- a/docs/.vitepress/theme/styles/home.css
+++ b/docs/.vitepress/theme/styles/home.css
@@ -147,7 +147,12 @@
 	display: block;
 	line-height: 1.65;
 }
-.recent-list time {
+.recent-list .index-byline {
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 4px 12px;
+	margin-top: 6px;
 	font-size: 11px;
 	color: var(--vp-c-text-3);
 }

--- a/docs/.vitepress/theme/styles/tokens.css
+++ b/docs/.vitepress/theme/styles/tokens.css
@@ -10,11 +10,25 @@
 	--vp-c-brand-2: hsl(var(--wiki-hue) 41% 34%);
 	--vp-c-brand-3: hsl(var(--wiki-hue) 38% 36%);
 	--vp-c-brand-soft: color-mix(in srgb, var(--vp-c-brand-1) 12%, transparent);
-	--vp-font-family-base: "Inter", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+	--vp-font-family-base: "InterVariable", "Inter", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
 	--vp-font-family-mono: "Cascadia Code", "JetBrains Mono", ui-monospace, monospace;
 }
 .dark {
 	--vp-c-brand-1: hsl(var(--wiki-hue) 43% 68%);
 	--vp-c-brand-2: hsl(var(--wiki-hue) 51% 75%);
 	--vp-c-brand-3: hsl(var(--wiki-hue) 41% 34%);
+}
+
+/* ESLint's CSS grammar does not yet recognize the standard @styleset descriptors. */
+/* eslint-disable css/no-invalid-at-rules */
+@font-feature-values "InterVariable", "Inter" {
+	@styleset {
+		open-digits: 1;
+		disambiguation: 2;
+		round-quotes-and-commas: 3;
+	}
+}
+/* eslint-enable css/no-invalid-at-rules */
+:root {
+	font-variant-alternates: styleset(open-digits, disambiguation, round-quotes-and-commas);
 }


### PR DESCRIPTION
改善 VitePress 迁移后的导航层级、文章信息布局和标签交互，使列表更紧凑、组件样式更一致。

- 侧栏增加按层级切换的汉字、数字、小写字母和罗马数字序号，修正全部目录与导航之间的间距。
- Article Index 将筛选提示放入输入框，布局切换统一放在右侧；列表左侧展示标题与标签，右侧展示日期与作者。卡片支持整卡点击，标签仍可独立访问，并修复末项重复分隔线。
- 首页、文章和索引复用 WikiChips；首页最近更新与索引复用日期、作者图标组件。姓名使用文章 author 字段。
- 文章分类改为面包屑，增加二、三级标题装饰，统一“源代码”链接指向 blame，修正搜索框局部焦点轮廓。
- 使用不内置 Inter 的默认主题，参考 Blog V3 从 CDN 引入字体，并通过具名 OpenType 样式集开启字体特性。
- 纳入项目级 VS Code 设置，启用保存格式化及 ESLint Fix，Markdown 使用 Markdown All in One。

验证：pnpm check（类型检查、ESLint、6 项测试）及 pnpm build 均通过；已回归保定数据科学指南多级导航、列表/卡片切换、标签跳转和搜索框焦点。构建仍有现有的超过 500 kB 分包提示。