### PR TITLE
修复全文搜索漏索引，支持中文分词与正文高亮

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -42,9 +42,11 @@ export default defineConfig({
 			async _render(source, env, md) {
 				const article = articles.find(item => item.source === env.relativePath || outputPath(item.url) === env.relativePath)
 				const html = await md.renderAsync(source, env)
+				if (env.frontmatter?.search === false)
+					return ''
 				if (!article || article.hasHeading)
 					return html
-				return `<h1 id="article-title">${md.utils.escapeHtml(article.title)}</h1>\n${html}`
+				return `<h1 id="article-title">${md.utils.escapeHtml(article.title)}<a class="header-anchor" href="#article-title" aria-hidden="true"></a></h1>\n${html}`
 			},
 			locales: { root: { translations: {
 				button: { buttonText: '搜索文档', buttonAriaLabel: '搜索文档' },
@@ -77,10 +79,10 @@ export default defineConfig({
 					return rendered
 				return `<a class="wiki-image-zoom" href="${md.utils.escapeHtml(src)}" target="_blank" rel="noopener" aria-label="查看原图">${rendered}</a>`
 			}
-			const headingClose = md.renderer.rules.heading_close
-			md.renderer.rules.heading_close = (tokens, index, options, env, self) => {
+			const headingOpen = md.renderer.rules.heading_open
+			md.renderer.rules.heading_open = (tokens, index, options, env, self) => {
 				const decoration = tokens[index].tag === 'h2' ? '<span class="heading-wordmark" aria-hidden="true"></span>' : ''
-				return decoration + (headingClose?.(tokens, index, options, env, self) ?? self.renderToken(tokens, index, options))
+				return (headingOpen?.(tokens, index, options, env, self) ?? self.renderToken(tokens, index, options)) + decoration
 			}
 		},
 		languageAlias: { gitignore: 'text' },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -39,14 +39,18 @@ export default defineConfig({
 		],
 		sidebar,
 		search: { provider: 'local', options: {
+			detailedView: true,
+			miniSearch: {
+				options: {
+					tokenize: text => Array.from(new Intl.Segmenter('zh-CN', { granularity: 'word' }).segment(text))
+						.filter(part => part.isWordLike)
+						.map(part => part.segment),
+				},
+				searchOptions: { combineWith: 'AND' },
+			},
 			async _render(source, env, md) {
-				const article = articles.find(item => item.source === env.relativePath || outputPath(item.url) === env.relativePath)
 				const html = await md.renderAsync(source, env)
-				if (env.frontmatter?.search === false)
-					return ''
-				if (!article || article.hasHeading)
-					return html
-				return `<h1 id="article-title">${md.utils.escapeHtml(article.title)}<a class="header-anchor" href="#article-title" aria-hidden="true"></a></h1>\n${html}`
+				return env.frontmatter?.search === false ? '' : html
 			},
 			locales: { root: { translations: {
 				button: { buttonText: '搜索文档', buttonAriaLabel: '搜索文档' },
@@ -71,6 +75,16 @@ export default defineConfig({
 	markdown: {
 		config: (md) => {
 			cardlist(md)
+			// The visible title lives in ArticleMeta. Local search mounts only the
+			// Markdown component, so it needs its own hidden heading for excerpts.
+			md.core.ruler.push('article-search-title', (state) => {
+				const article = articles.find(item => item.source === state.env.relativePath || outputPath(item.url) === state.env.relativePath)
+				if (!article || article.hasHeading)
+					return
+				const heading = new state.Token('html_block', '', 0)
+				heading.content = `<h1 hidden aria-hidden="true">${md.utils.escapeHtml(article.title)}<a class="header-anchor" href="#article-title" aria-hidden="true"></a></h1>\n`
+				state.tokens.unshift(heading)
+			})
 			const image = md.renderer.rules.image
 			md.renderer.rules.image = (tokens, index, options, env, self) => {
 				const rendered = image?.(tokens, index, options, env, self) ?? self.renderToken(tokens, index, options)

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -15,8 +15,11 @@ test('title-less table articles expose an anchored search heading and body', asy
 	const md = await renderer
 	const relativePath = '05.校园生活/01.常用账号与默认密码.md'
 	const html = await render(readFileSync(join(docsRoot, relativePath), 'utf8'), { relativePath, path: join(docsRoot, relativePath), cleanUrls: true }, md)
-	assert.match(html, /<h1 id="article-title">常用账号与默认密码<a[^>]+href="#article-title"[^>]*><\/a><\/h1>/)
+	assert.match(html, /<h1 hidden aria-hidden="true">常用账号与默认密码<a[^>]+href="#article-title"[^>]*><\/a><\/h1>/)
 	assert.match(html, /华电邮箱/)
+	const pageHtml = await md.renderAsync(readFileSync(join(docsRoot, relativePath), 'utf8'), { relativePath })
+	assert.match(pageHtml, /<h1 hidden aria-hidden="true">.*href="#article-title"/)
+	assert.match(pageHtml, /华电邮箱/)
 })
 
 test('heading decorations preserve the trailing anchor required by local search', async () => {
@@ -28,4 +31,12 @@ test('heading decorations preserve the trailing anchor required by local search'
 test('custom search rendering respects search false', async () => {
 	const md = await renderer
 	assert.equal(await render('---\nsearch: false\n---\n# 不索引\n\n正文', { relativePath: 'hidden.md', path: join(docsRoot, 'hidden.md'), cleanUrls: true }, md), '')
+})
+
+test('Chinese tokenization matches email independently of its campus prefix', () => {
+	const tokenize = search.options!.miniSearch!.options!.tokenize!
+	assert.ok(tokenize('华电邮箱').includes('邮箱'))
+	assert.deepEqual(tokenize('邮箱'), ['邮箱'])
+	assert.ok(tokenize('华北电力大学电子邮箱').includes('邮箱'))
+	assert.ok(tokenize('VPN 与 GitHub').includes('GitHub'))
 })

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import test from 'node:test'
+import { createMarkdownRenderer } from 'vitepress'
+import { docsRoot } from '../docs/.vitepress/catalog.ts'
+import config from '../docs/.vitepress/config.mts'
+
+const renderer = createMarkdownRenderer(docsRoot, config.markdown)
+const search = config.themeConfig!.search!
+assert.ok(search.provider === 'local')
+const render = search.options!._render!
+
+test('title-less table articles expose an anchored search heading and body', async () => {
+	const md = await renderer
+	const relativePath = '05.校园生活/01.常用账号与默认密码.md'
+	const html = await render(readFileSync(join(docsRoot, relativePath), 'utf8'), { relativePath, path: join(docsRoot, relativePath), cleanUrls: true }, md)
+	assert.match(html, /<h1 id="article-title">常用账号与默认密码<a[^>]+href="#article-title"[^>]*><\/a><\/h1>/)
+	assert.match(html, /华电邮箱/)
+})
+
+test('heading decorations preserve the trailing anchor required by local search', async () => {
+	const md = await renderer
+	const html = await md.renderAsync('## 知识技能掌握\n\n正文')
+	assert.match(html, /<h2[^>]*><span class="heading-wordmark" aria-hidden="true"><\/span>知识技能掌握\s*<a[^>]+href="#知识技能掌握"[^>]*>.*?<\/a><\/h2>/)
+})
+
+test('custom search rendering respects search false', async () => {
+	const md = await renderer
+	assert.equal(await render('---\nsearch: false\n---\n# 不索引\n\n正文', { relativePath: 'hidden.md', path: join(docsRoot, 'hidden.md'), cleanUrls: true }, md), '')
+})


### PR DESCRIPTION
修复“华电邮箱”无法检索，以及完整词能搜到但“邮箱”搜不到的问题，并让搜索结果默认展示高亮正文。

- 为主题生成标题的文章补充隐藏的带锚点标题，使无 Markdown 一级标题的页面能进入索引，也能被详细结果模式提取正文。
- 调整二级标题装饰的位置，保留 VitePress 搜索识别所需的末尾锚点；自定义渲染继续遵守 search: false。
- 使用 Intl.Segmenter 进行中文分词，查询词采用 AND 组合，支持“华电邮箱”“邮箱”等检索，无新增依赖。
- 默认启用正文详情及关键词高亮，片段按需加载，不将整段正文额外存入索引。

验证：类型检查、ESLint、10 项测试及生产构建通过；已在浏览器确认“邮箱”命中“常用账号与默认密码”并高亮正文。当前索引约 861 KB，本地 gzip 压缩约 216 KB、Brotli 约 155 KB。构建仍有现有的超过 500 kB 分包提示。