### PR TITLE
feat: 整串匹配本地搜索，支持跳转首处命中

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,8 +1,10 @@
+import type { MarkdownOptions } from 'vitepress'
 import { fileURLToPath } from 'node:url'
 import markmapPlugin from '@vitepress-plugin/markmap'
 import { defineConfig } from 'vitepress'
 import { cardlist } from './cardlist.ts'
-import { buildTree, outputPath, scanArticles } from './catalog.ts'
+import { buildTree, docsRoot, outputPath, scanArticles } from './catalog.ts'
+import { writeSearchIndex } from './search-index.ts'
 
 const articles = scanArticles()
 function topicMatch(slug: string, ...folders: string[]) {
@@ -14,6 +16,38 @@ const rewrites = new Map(articles.map(article => [article.source, outputPath(art
 const sidebar = Object.fromEntries(articles.map(article => [article.url, [
 	...buildTree(articles.filter(other => other.folders[0] === article.folders[0])),
 ]]))
+
+const markdownOptions: MarkdownOptions = {
+	config: (md) => {
+		cardlist(md)
+		// 无 Markdown 一级标题的文章，正文渲染时不包含标题文本。
+		// 这里插入一个隐藏 h1，保证搜索索引能拿到标题，也让标题可被整串匹配。
+		md.core.ruler.push('article-search-title', (state) => {
+			const article = articles.find(item => item.source === state.env.relativePath || outputPath(item.url) === state.env.relativePath)
+			if (!article || article.hasHeading)
+				return
+			const heading = new state.Token('html_block', '', 0)
+			heading.content = `<h1 hidden aria-hidden="true">${md.utils.escapeHtml(article.title)}<a class="header-anchor" href="#article-title" aria-hidden="true"></a></h1>\n`
+			state.tokens.unshift(heading)
+		})
+		const image = md.renderer.rules.image
+		md.renderer.rules.image = (tokens, index, options, env, self) => {
+			const rendered = image?.(tokens, index, options, env, self) ?? self.renderToken(tokens, index, options)
+			const src = tokens[index].attrGet('src') || ''
+			if (!src || src.startsWith('data:'))
+				return rendered
+			return `<a class="wiki-image-zoom" href="${md.utils.escapeHtml(src)}" target="_blank" rel="noopener" aria-label="查看原图">${rendered}</a>`
+		}
+		const headingOpen = md.renderer.rules.heading_open
+		md.renderer.rules.heading_open = (tokens, index, options, env, self) => {
+			const decoration = tokens[index].tag === 'h2' ? '<span class="heading-wordmark" aria-hidden="true"></span>' : ''
+			return (headingOpen?.(tokens, index, options, env, self) ?? self.renderToken(tokens, index, options)) + decoration
+		}
+	},
+	languageAlias: { gitignore: 'text' },
+	math: true,
+	container: { tipLabel: '提示', warningLabel: '注意', dangerLabel: '警告', infoLabel: '信息', detailsLabel: '详细信息' },
+}
 
 export default defineConfig({
 	lang: 'zh-CN',
@@ -38,25 +72,6 @@ export default defineConfig({
 			{ text: '参与共建', link: '/pages/BasicContribution/', activeMatch: topicMatch('contribute', '贡献与其他') },
 		],
 		sidebar,
-		search: { provider: 'local', options: {
-			detailedView: true,
-			miniSearch: {
-				options: {
-					tokenize: text => Array.from(new Intl.Segmenter('zh-CN', { granularity: 'word' }).segment(text))
-						.filter(part => part.isWordLike)
-						.map(part => part.segment),
-				},
-				searchOptions: { combineWith: 'AND' },
-			},
-			async _render(source, env, md) {
-				const html = await md.renderAsync(source, env)
-				return env.frontmatter?.search === false ? '' : html
-			},
-			locales: { root: { translations: {
-				button: { buttonText: '搜索文档', buttonAriaLabel: '搜索文档' },
-				modal: { displayDetails: '显示详情', resetButtonTitle: '清除搜索', backButtonTitle: '关闭搜索', noResultsText: '没有找到相关结果', footer: { selectText: '选择', navigateText: '切换', closeText: '关闭' } },
-			} } },
-		} },
 		socialLinks: [{ icon: 'github', link: 'https://github.com/NCEPUwiki/NCEPUwiki' }],
 		externalLinkIcon: true,
 		langMenuLabel: '切换语言',
@@ -71,37 +86,21 @@ export default defineConfig({
 		lastUpdated: { text: '最后更新于', formatOptions: { dateStyle: 'medium' } },
 		footer: { message: '由华电学生共同维护的非官方校园知识库', copyright: `© 2025–${new Date().getFullYear()} NCEPUwiki-Group · MIT License` },
 	},
-	vite: { plugins: [markmapPlugin({ containerHeight: 500 })], resolve: { alias: { '@': fileURLToPath(new URL('./', import.meta.url)) } } },
-	markdown: {
-		config: (md) => {
-			cardlist(md)
-			// The visible title lives in ArticleMeta. Local search mounts only the
-			// Markdown component, so it needs its own hidden heading for excerpts.
-			md.core.ruler.push('article-search-title', (state) => {
-				const article = articles.find(item => item.source === state.env.relativePath || outputPath(item.url) === state.env.relativePath)
-				if (!article || article.hasHeading)
-					return
-				const heading = new state.Token('html_block', '', 0)
-				heading.content = `<h1 hidden aria-hidden="true">${md.utils.escapeHtml(article.title)}<a class="header-anchor" href="#article-title" aria-hidden="true"></a></h1>\n`
-				state.tokens.unshift(heading)
-			})
-			const image = md.renderer.rules.image
-			md.renderer.rules.image = (tokens, index, options, env, self) => {
-				const rendered = image?.(tokens, index, options, env, self) ?? self.renderToken(tokens, index, options)
-				const src = tokens[index].attrGet('src') || ''
-				if (!src || src.startsWith('data:'))
-					return rendered
-				return `<a class="wiki-image-zoom" href="${md.utils.escapeHtml(src)}" target="_blank" rel="noopener" aria-label="查看原图">${rendered}</a>`
-			}
-			const headingOpen = md.renderer.rules.heading_open
-			md.renderer.rules.heading_open = (tokens, index, options, env, self) => {
-				const decoration = tokens[index].tag === 'h2' ? '<span class="heading-wordmark" aria-hidden="true"></span>' : ''
-				return (headingOpen?.(tokens, index, options, env, self) ?? self.renderToken(tokens, index, options)) + decoration
-			}
+	vite: {
+		plugins: [markmapPlugin({ containerHeight: 500 })],
+		resolve: {
+			alias: {
+				'@': fileURLToPath(new URL('./', import.meta.url)),
+				// 用自研整串搜索替换 VitePress 默认主题导航栏里的搜索组件
+				'./VPNavBarSearch.vue': fileURLToPath(new URL('./theme/components/WikiSearch.vue', import.meta.url)),
+			},
 		},
-		languageAlias: { gitignore: 'text' },
-		math: true,
-		container: { tipLabel: '提示', warningLabel: '注意', dangerLabel: '警告', infoLabel: '信息', detailsLabel: '详细信息' },
+	},
+	markdown: markdownOptions,
+	// 站点构建完成后，把渲染后的纯文本索引写入 dist/search-index.json，
+	// WikiSearch.vue 打开搜索框时再按需 fetch。
+	async buildEnd(siteConfig) {
+		await writeSearchIndex({ articles, docsRoot, outDir: siteConfig.outDir, markdown: markdownOptions })
 	},
 	transformPageData(page) {
 		const article = articles.find(item => item.source === page.relativePath || outputPath(item.url) === page.relativePath)

--- a/docs/.vitepress/search-index.ts
+++ b/docs/.vitepress/search-index.ts
@@ -1,0 +1,87 @@
+import type { MarkdownOptions } from 'vitepress'
+import type { Article } from './types.ts'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import matter from 'gray-matter'
+import { createMarkdownRenderer } from 'vitepress'
+
+/**
+ * 构建期生成的搜索索引（docs/.vitepress/dist/search-index.json）。
+ *
+ * 每个条目保存一篇文章渲染后的完整纯文本。搜索时不分词、不拆字，
+ * 而是把用户输入的整段文字作为连续字符串在 text 中查找，
+ * 页面只有“完整包含这段连续文字”才算命中。
+ */
+export interface SearchRecord {
+	/** 页面在站内的路由，例如 /pages/accountpassword */
+	route: string
+	/** 文章标题（无 Markdown 一级标题时使用 frontmatter/文件名推断） */
+	title: string
+	/** 文章在目录中的层级，例如 校园生活 / 常用信息 */
+	folders: string[]
+	/** 渲染后的整篇正文纯文本，供整串匹配和摘要展示 */
+	text: string
+}
+
+/** 把 Markdown 渲染出的 HTML 粗略转成可读纯文本。 */
+function stripHtml(html: string): string {
+	const noBlocks = html
+		.replace(/<style[\s\S]*?<\/style>/gi, ' ')
+		.replace(/<script[\s\S]*?<\/script>/gi, ' ')
+		// 块级结束标签换成换行，让不同段落/表格行自然断开
+		.replace(/<br\s*\/?>/gi, '\n')
+		.replace(/<\/(p|div|li|tr|h[1-6]|pre|blockquote|figure)>/gi, '\n')
+		.replace(/<\/t[dh]>/gi, ' ')
+	return noBlocks
+		.replace(/<[^>]+>/g, ' ')
+		// 还原常见 HTML 实体（含零宽字符等数字实体），避免夹在正文里影响连续匹配
+		.replace(/&nbsp;/g, ' ')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, '\'')
+		.replace(/&amp;/g, '&')
+		.replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number(code)))
+		.replace(/&#x([0-9a-f]+);/gi, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 16)))
+		.replace(/[ \t]+\n/g, '\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim()
+}
+
+/**
+ * 在 VitePress buildEnd 阶段调用，把文章列表写入 search-index.json。
+ */
+export async function writeSearchIndex(options: {
+	articles: Article[]
+	docsRoot: string
+	outDir: string
+	markdown: MarkdownOptions
+}) {
+	const { articles, docsRoot, outDir, markdown } = options
+	const md = await createMarkdownRenderer(docsRoot, markdown)
+	const records: SearchRecord[] = []
+
+	for (const article of articles) {
+		// 只含 frontmatter 的空占位页不进入搜索（正文为空，点进去也没有可跳转内容）
+		if (article.empty)
+			continue
+		const sourcePath = join(docsRoot, article.source)
+		const { data: frontmatter, content } = matter(await readFile(sourcePath, 'utf8'))
+		// 与旧版保持一致：frontmatter 里声明 search: false 的页面不进索引
+		if (frontmatter.search === false)
+			continue
+		// 用与正式站点一致的 markdown 配置渲染，再剥离标签得到纯文本
+		const html = await md.renderAsync(content, { relativePath: article.source, path: sourcePath, cleanUrls: true })
+		const text = stripHtml(html)
+		if (!text)
+			continue
+		records.push({
+			route: article.url,
+			title: article.title,
+			folders: article.folders,
+			text,
+		})
+	}
+
+	await writeFile(join(outDir, 'search-index.json'), JSON.stringify(records), 'utf8')
+}

--- a/docs/.vitepress/theme/components/WikiSearch.vue
+++ b/docs/.vitepress/theme/components/WikiSearch.vue
@@ -1,0 +1,679 @@
+<script setup lang="ts">
+import { useRouter, withBase } from 'vitepress'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+// 与 docs/.vitepress/search-index.ts 中 SearchRecord 对应：
+// 一条记录 = 一篇文章的完整纯文本。
+interface IndexRecord {
+	route: string
+	title: string
+	folders: string[]
+	text: string
+}
+
+// 加载索引时预先归一化标题/正文，搜索过程不用反复扫描原始文本。
+interface LoadedRecord extends IndexRecord {
+	normalizedText: string
+	normalizedTitle: string
+}
+
+interface ResultItem {
+	record: LoadedRecord
+	snippet: string
+	titleHit: boolean
+}
+
+const router = useRouter()
+const visible = ref(false)
+const query = ref('')
+const loading = ref(false)
+const results = ref<ResultItem[]>([])
+const selectedIndex = ref(-1)
+const inputEl = ref<HTMLInputElement | null>(null)
+const listEl = ref<HTMLDivElement | null>(null)
+
+let indexPromise: Promise<LoadedRecord[] | null> | null = null
+let debounceTimer: ReturnType<typeof setTimeout> | undefined
+let searchSeq = 0
+
+/**
+ * 归一化策略（索引与查询共用）：
+ * - 不做任何中文分词；
+ * - 仅去除空白、标点、符号和不可见格式字符并统一小写；
+ * - 因此查询必须作为“连续的一段字符”出现在页面文本里才算命中。
+ */
+function normalize(text: string): string {
+	return text.normalize('NFKC').toLowerCase().replace(/[\s\p{P}\p{S}\p{Cf}]+/gu, '')
+}
+
+/** HTML 转义，用于安全渲染用户可控的查询文本。 */
+function escapeHtml(value: string): string {
+	return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll('\'', '&#39;')
+}
+
+/** 正则转义，用于把普通文本当作字面量去高亮。 */
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** 首次使用时才 fetch search-index.json，之后复用同一个 Promise。 */
+function loadIndex(): Promise<LoadedRecord[] | null> {
+	if (!indexPromise) {
+		loading.value = true
+		indexPromise = fetch(withBase('/search-index.json'))
+			.then(async (response) => {
+				if (!response.ok)
+					throw new Error(`搜索索引加载失败：${response.status}`)
+				const records = await response.json() as IndexRecord[]
+				return records.map(record => ({
+					...record,
+					normalizedText: normalize(record.text),
+					normalizedTitle: normalize(record.title),
+				}))
+			})
+			.catch(() => null)
+			.finally(() => {
+				loading.value = false
+			})
+	}
+	return indexPromise
+}
+
+/**
+ * 根据“归一化文本中的命中位置”估算原始文本中的截取范围，
+ * 生成结果列表里展示的摘要片段（前后补省略号）。
+ */
+function makeSnippet(record: LoadedRecord, indexInNormalized: number): string {
+	const text = record.text
+	const start = Math.max(0, Math.floor(indexInNormalized / Math.max(1, record.normalizedText.length) * text.length) - 48)
+	const end = Math.min(text.length, start + 190)
+	const prefix = start > 0 ? '…' : ''
+	const suffix = end < text.length ? '…' : ''
+	return `${prefix}${text.slice(start, end).replace(/\s+/g, ' ')}${suffix}`
+}
+
+interface FoundMatch {
+	node: Text
+	start: number
+	end: number
+}
+
+/** 直接在单个文本节点里找“和用户输入一字不差”的首次出现。 */
+function findExactText(root: Element, query: string): FoundMatch | null {
+	const rawQuery = query.trim().replace(/\s+/g, ' ')
+	if (!rawQuery)
+		return null
+	const lowerQuery = rawQuery.toLowerCase()
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+	for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+		const text = node as Text
+		const index = text.data.toLowerCase().indexOf(lowerQuery)
+		if (index >= 0)
+			return { node: text, start: index, end: index + rawQuery.length }
+	}
+	return null
+}
+
+/**
+ * 兜底查找：正文可能因换行/标点/零宽字符导致无法“一字不差”匹配，
+ * 于是把所有文本节点归一化后拼起来定位首次命中，再映射回原始节点。
+ */
+function findNormalizedText(root: Element, normalizedQuery: string): FoundMatch | null {
+	const segments: { node: Text, norm: string }[] = []
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+	for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+		const text = node as Text
+		const norm = normalize(text.data)
+		if (norm)
+			segments.push({ node: text, norm })
+	}
+	const combined = segments.map(segment => segment.norm).join('')
+	const combinedIndex = combined.indexOf(normalizedQuery)
+	if (combinedIndex < 0)
+		return null
+
+	let offset = 0
+	for (const segment of segments) {
+		if (combinedIndex < offset + segment.norm.length) {
+			const segmentOffset = combinedIndex - offset
+			let rawOffset = 0
+			let skipped = 0
+			for (let rawIndex = 0; rawIndex < segment.node.data.length && skipped < segmentOffset; rawIndex++) {
+				const character = segment.node.data[rawIndex]
+				if (!/[\s\p{P}\p{S}\p{Cf}]/u.test(character)) {
+					skipped++
+					rawOffset = rawIndex + 1
+				}
+			}
+			return { node: segment.node, start: rawOffset, end: Math.min(segment.node.data.length, rawOffset + normalizedQuery.length) }
+		}
+		offset += segment.norm.length
+	}
+	return null
+}
+
+/**
+ * 用 <mark> 包裹命中文字、滚动到视野中央，并在数秒后还原原文。
+ */
+function markAndScroll(match: FoundMatch) {
+	const parent = match.node.parentNode
+	if (!parent)
+		return
+	// 先把命中片段从文本节点里“切”出来，再用 mark 替换它
+	match.node.splitText(match.end)
+	const matchNode = match.node.splitText(match.start)
+	const mark = document.createElement('mark')
+	mark.className = 'wiki-search-jump'
+	parent.replaceChild(mark, matchNode)
+	mark.appendChild(matchNode)
+	mark.scrollIntoView({ block: 'center', behavior: 'smooth' })
+	setTimeout(() => {
+		if (!mark.isConnected)
+			return
+		// 还原被 mark 包裹的文本，避免永久改变文章 DOM
+		const content = mark.firstChild
+		if (content)
+			parent.insertBefore(content, mark)
+		mark.remove()
+	}, 3500)
+}
+
+/**
+ * 跳转后等文章正文渲染出来，然后定位并高亮第一个命中位置。
+ * 页面存在多个 .vp-doc（例如 ArticleMeta 与正文），因此遍历正文根节点。
+ */
+async function jumpToFirstMatch(query: string) {
+	const normalizedQuery = normalize(query)
+	if (!normalizedQuery)
+		return
+
+	await nextTick()
+	const deadline = Date.now() + 3000
+	while (Date.now() < deadline) {
+		const roots = [...document.querySelectorAll('main .vp-doc')]
+		if (!roots.length)
+			roots.push(...document.querySelectorAll('.vp-doc:not(.article-meta)'))
+		if (!roots.length)
+			roots.push(document.querySelector('main')!)
+		for (const root of roots) {
+			const exact = findExactText(root, query)
+			if (exact) {
+				markAndScroll(exact)
+				return
+			}
+			const normalized = findNormalizedText(root, normalizedQuery)
+			if (normalized) {
+				markAndScroll(normalized)
+				return
+			}
+		}
+		await new Promise(resolve => setTimeout(resolve, 80))
+	}
+}
+
+/** 生成结果摘要，并把命中的整串文字用 <mark> 高亮。 */
+function highlightSnippet(record: LoadedRecord, indexInNormalized: number): string {
+	const snippet = escapeHtml(makeSnippet(record, indexInNormalized))
+	const rawQuery = query.value.trim().replace(/\s+/g, ' ')
+	if (!rawQuery)
+		return snippet
+	const pattern = new RegExp(`(${escapeRegExp(rawQuery)})`, 'gi')
+	return snippet.replace(pattern, '<mark>$1</mark>')
+}
+
+/**
+ * 真正的搜索：对每一页执行“归一化全文 contains 归一化查询”。
+ * 标题命中优先，其次按正文中首次出现位置排序，最多展示 20 条。
+ */
+async function performSearch() {
+	const normalizedQuery = normalize(query.value)
+	const seq = ++searchSeq
+	if (!normalizedQuery) {
+		results.value = []
+		selectedIndex.value = -1
+		return
+	}
+
+	const records = await loadIndex()
+	if (seq !== searchSeq)
+		return
+	if (!records) {
+		results.value = []
+		selectedIndex.value = -1
+		return
+	}
+
+	const matches: { record: LoadedRecord, index: number, titleHit: boolean }[] = []
+	for (const record of records) {
+		const index = record.normalizedText.indexOf(normalizedQuery)
+		if (index >= 0) {
+			matches.push({
+				record,
+				index,
+				titleHit: record.normalizedTitle.includes(normalizedQuery),
+			})
+		}
+	}
+
+	matches.sort((a, b) => Number(b.titleHit) - Number(a.titleHit) || a.index - b.index)
+	results.value = matches.slice(0, 20).map(match => ({
+		record: match.record,
+		snippet: highlightSnippet(match.record, match.index),
+		titleHit: match.titleHit,
+	}))
+	selectedIndex.value = results.value.length ? 0 : -1
+}
+
+/** 用方向键在结果间移动选择。 */
+function moveSelection(step: number) {
+	if (!results.value.length)
+		return
+	selectedIndex.value = (selectedIndex.value + step + results.value.length) % results.value.length
+}
+
+/** 打开结果页面，并在正文里跳到输入内容首次出现的位置。 */
+async function openResult(route: string) {
+	const matchedQuery = query.value
+	closeSearch()
+	await router.go(withBase(route))
+	await jumpToFirstMatch(matchedQuery)
+}
+
+/** 搜索框内键盘操作：上下选择、回车打开、Esc 关闭。 */
+function onInputKeydown(event: KeyboardEvent) {
+	if (event.key === 'ArrowDown') {
+		event.preventDefault()
+		moveSelection(1)
+	}
+	else if (event.key === 'ArrowUp') {
+		event.preventDefault()
+		moveSelection(-1)
+	}
+	else if (event.key === 'Enter') {
+		event.preventDefault()
+		const item = results.value[selectedIndex.value]
+		if (item)
+			openResult(item.record.route)
+	}
+	else if (event.key === 'Escape') {
+		event.preventDefault()
+		closeSearch()
+	}
+}
+
+/** 全局快捷键：任意页面按 Ctrl/Cmd+K 打开搜索。 */
+function onGlobalKeydown(event: KeyboardEvent) {
+	if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+		event.preventDefault()
+		openSearch()
+	}
+}
+
+/** 打开搜索弹窗并预加载索引，避免首次输入等待。 */
+async function openSearch() {
+	if (!visible.value) {
+		query.value = ''
+		results.value = []
+	}
+	visible.value = true
+	await nextTick()
+	inputEl.value?.focus()
+	void loadIndex()
+}
+
+/** 关闭并清空状态，下次打开从空白开始。 */
+function closeSearch() {
+	visible.value = false
+	query.value = ''
+	results.value = []
+	selectedIndex.value = -1
+}
+
+// 输入防抖：停止输入 180ms 后再搜索
+watch(query, () => {
+	clearTimeout(debounceTimer)
+	debounceTimer = setTimeout(() => {
+		void performSearch()
+	}, 180)
+})
+
+// 键盘/鼠标选中项变化时保证它在可视区域内
+watch(selectedIndex, async () => {
+	await nextTick()
+	listEl.value?.querySelector('.selected')?.scrollIntoView({ block: 'nearest' })
+})
+
+const resultCountText = computed(() => results.value.length ? `共 ${results.value.length} 条结果` : '')
+
+onMounted(() => {
+	window.addEventListener('keydown', onGlobalKeydown)
+})
+
+// 卸载时移除全局快捷键与待执行的防抖任务
+onBeforeUnmount(() => {
+	window.removeEventListener('keydown', onGlobalKeydown)
+	clearTimeout(debounceTimer)
+})
+</script>
+
+<template>
+<div class="wiki-search">
+	<button class="wiki-search-button" type="button" aria-label="搜索文档" @click="openSearch">
+		<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="m21 21-4.3-4.3M11 19a8 8 0 1 1 0-16 8 8 0 0 1 0 16Z" /></svg>
+		<span class="label">搜索文档</span>
+		<span class="shortcut">Ctrl K</span>
+	</button>
+
+	<Teleport to="body">
+		<div v-if="visible" class="wiki-search-mask" @click.self="closeSearch">
+			<div class="wiki-search-panel" role="dialog" aria-modal="true" aria-label="搜索文档">
+				<div class="wiki-search-bar">
+					<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="m21 21-4.3-4.3M11 19a8 8 0 1 1 0-16 8 8 0 0 1 0 16Z" /></svg>
+					<input
+						ref="inputEl"
+						v-model="query"
+						class="wiki-search-input"
+						type="text"
+						placeholder="输入要查找的文字，例如：华电邮箱"
+						autocomplete="off"
+						spellcheck="false"
+						@keydown="onInputKeydown"
+					>
+					<button v-if="query" class="wiki-search-clear" type="button" aria-label="清除搜索" @click="query = ''">
+						<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M18 6 6 18M6 6l12 12" /></svg>
+					</button>
+				</div>
+
+				<div v-if="resultCountText" class="wiki-search-summary">
+					{{ resultCountText }}
+				</div>
+
+				<div ref="listEl" class="wiki-search-results" role="listbox">
+					<p v-if="loading && !results.length" class="wiki-search-status">
+						正在加载索引…
+					</p>
+					<p v-else-if="query && !loading && !results.length" class="wiki-search-status">
+						没有找到完整包含这段文字的页面
+					</p>
+					<p v-else-if="!query" class="wiki-search-status">
+						搜索时会把整段文字当作连续内容匹配
+					</p>
+
+					<button
+						v-for="(item, index) in results"
+						:key="item.record.route"
+						class="wiki-search-result"
+						:class="{ selected: index === selectedIndex }"
+						type="button"
+						role="option"
+						:aria-selected="index === selectedIndex"
+						@click="openResult(item.record.route)"
+						@mouseenter="selectedIndex = index"
+					>
+						<span class="wiki-search-result-title">
+							<svg v-if="item.titleHit" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 6 9 17l-5-5" /></svg>
+							{{ item.record.title }}
+						</span>
+						<span v-if="item.record.folders.length" class="wiki-search-result-path">{{ item.record.folders.join(' / ') }}</span>
+						<!-- eslint-disable-next-line vue/no-v-html -->
+						<span class="wiki-search-result-snippet" v-html="item.snippet" />
+					</button>
+				</div>
+
+				<div class="wiki-search-footer">
+					<span><kbd>↑</kbd><kbd>↓</kbd> 选择</span>
+					<span><kbd>Enter</kbd> 打开</span>
+					<span><kbd>Esc</kbd> 关闭</span>
+				</div>
+			</div>
+		</div>
+	</Teleport>
+</div>
+</template>
+
+<style scoped>
+.wiki-search {
+	display: flex;
+	flex: 1;
+	padding-left: 24px;
+}
+
+.wiki-search-button {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	height: 40px;
+	padding: 0 10px 0 12px;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	background: var(--vp-c-bg-alt);
+	color: var(--vp-c-text-2);
+	transition: border-color 0.2s, color 0.2s;
+	cursor: pointer;
+}
+
+.wiki-search-button:hover {
+	border-color: var(--vp-c-brand-1);
+	color: var(--vp-c-text-1);
+}
+
+.wiki-search-button svg {
+	width: 14px;
+	height: 14px;
+}
+
+.wiki-search-button .shortcut {
+	padding: 1px 6px;
+	border: 1px solid var(--vp-c-divider);
+	border-radius: 4px;
+	font-size: 12px;
+	line-height: 18px;
+}
+
+.wiki-search-mask {
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	position: fixed;
+	inset: 0;
+	padding: 12vh 16px 24px;
+	background: rgb(0 0 0 / 45%);
+	z-index: 90;
+}
+
+.wiki-search-panel {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	width: min(680px, 100%);
+	max-height: 72vh;
+	border: 1px solid var(--vp-c-divider);
+	border-radius: 12px;
+	box-shadow: 0 18px 50px rgb(0 0 0 / 20%);
+	background: var(--vp-c-bg);
+}
+
+.wiki-search-bar {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 14px 16px;
+	border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.wiki-search-bar > svg {
+	flex: none;
+	width: 18px;
+	height: 18px;
+	color: var(--vp-c-text-2);
+}
+
+.wiki-search-input {
+	flex: 1;
+	min-width: 0;
+	border: 0;
+	outline: 0;
+	background: transparent;
+	font: inherit;
+	color: var(--vp-c-text-1);
+}
+
+.wiki-search-input::placeholder {
+	color: var(--vp-c-text-3);
+}
+
+.wiki-search-clear {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 6px;
+	border: 0;
+	border-radius: 6px;
+	background: transparent;
+	color: var(--vp-c-text-2);
+	cursor: pointer;
+}
+
+.wiki-search-clear:hover {
+	background: var(--vp-c-bg-alt);
+	color: var(--vp-c-brand-1);
+}
+
+.wiki-search-clear svg {
+	width: 14px;
+	height: 14px;
+}
+
+.wiki-search-summary {
+	padding: 8px 16px 0;
+	font-size: 12px;
+	color: var(--vp-c-text-2);
+}
+
+.wiki-search-results {
+	flex: 1;
+	overflow: auto;
+	padding: 8px;
+}
+
+.wiki-search-status {
+	margin: 0;
+	padding: 18px 12px;
+	font-size: 14px;
+	text-align: center;
+	color: var(--vp-c-text-2);
+}
+
+.wiki-search-result {
+	display: block;
+	width: 100%;
+	padding: 10px 12px;
+	border: 0;
+	border-radius: 8px;
+	background: transparent;
+	text-align: left;
+	color: var(--vp-c-text-1);
+	cursor: pointer;
+}
+
+.wiki-search-result.selected,
+.wiki-search-result:hover {
+	background: var(--vp-c-bg-alt);
+}
+
+.wiki-search-result-title {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-weight: 600;
+}
+
+.wiki-search-result-title svg {
+	width: 13px;
+	height: 13px;
+	color: var(--vp-c-brand-1);
+}
+
+.wiki-search-result-path {
+	display: block;
+	margin-top: 2px;
+	font-size: 12px;
+	color: var(--vp-c-text-3);
+}
+
+.wiki-search-result-snippet {
+	display: -webkit-box;
+	overflow: hidden;
+	margin-top: 5px;
+	font-size: 13px;
+	-webkit-line-clamp: 3;
+	line-height: 1.6;
+	word-break: break-word;
+	color: var(--vp-c-text-2);
+	-webkit-box-orient: vertical;
+}
+
+.wiki-search-result-snippet :deep(mark) {
+	padding: 0 1px;
+	border-radius: 3px;
+	background: var(--vp-c-brand-soft);
+	color: var(--vp-c-brand-1);
+}
+
+.wiki-search-footer {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding: 8px 16px;
+	border-top: 1px solid var(--vp-c-divider);
+	font-size: 12px;
+	color: var(--vp-c-text-3);
+}
+
+.wiki-search-footer kbd {
+	display: inline-block;
+	min-width: 20px;
+	margin: 0 2px;
+	padding: 1px 5px;
+	border: 1px solid var(--vp-c-divider);
+	border-bottom-width: 2px;
+	border-radius: 4px;
+	font-family: inherit;
+	font-size: 11px;
+	text-align: center;
+}
+
+@media (max-width: 767px) {
+	.wiki-search {
+		flex: 0;
+		padding-left: 0;
+	}
+
+	.wiki-search-button {
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		border-radius: 0;
+		background: transparent;
+	}
+
+	.wiki-search-button .label,
+	.wiki-search-button .shortcut {
+		display: none;
+	}
+
+	.wiki-search-button svg {
+		width: 18px;
+		height: 18px;
+	}
+}
+</style>
+
+<style>
+.wiki-search-jump {
+	padding: 0 1px;
+	border-radius: 3px;
+	background: var(--vp-c-yellow-soft, #FFE58A);
+	color: inherit;
+}
+</style>

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,42 +1,45 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
 import { createMarkdownRenderer } from 'vitepress'
-import { docsRoot } from '../docs/.vitepress/catalog.ts'
+import { docsRoot, scanArticles } from '../docs/.vitepress/catalog.ts'
 import config from '../docs/.vitepress/config.mts'
+import { writeSearchIndex } from '../docs/.vitepress/search-index.ts'
 
-const renderer = createMarkdownRenderer(docsRoot, config.markdown)
-const search = config.themeConfig!.search!
-assert.ok(search.provider === 'local')
-const render = search.options!._render!
+// 与正式站点共用同一份 markdown 配置来渲染测试内容
+const renderer = createMarkdownRenderer(docsRoot, config.markdown!)
 
-test('title-less table articles expose an anchored search heading and body', async () => {
+test('title-less table articles expose an anchored heading and body text', async () => {
 	const md = await renderer
 	const relativePath = '05.校园生活/01.常用账号与默认密码.md'
-	const html = await render(readFileSync(join(docsRoot, relativePath), 'utf8'), { relativePath, path: join(docsRoot, relativePath), cleanUrls: true }, md)
-	assert.match(html, /<h1 hidden aria-hidden="true">常用账号与默认密码<a[^>]+href="#article-title"[^>]*><\/a><\/h1>/)
-	assert.match(html, /华电邮箱/)
-	const pageHtml = await md.renderAsync(readFileSync(join(docsRoot, relativePath), 'utf8'), { relativePath })
-	assert.match(pageHtml, /<h1 hidden aria-hidden="true">.*href="#article-title"/)
+	const source = readFileSync(join(docsRoot, relativePath), 'utf8')
+	const pageHtml = await md.renderAsync(source, { relativePath })
+	assert.match(pageHtml, /<h1 hidden aria-hidden="true">常用账号与默认密码<a[^>]+href="#article-title"[^>]*><\/a><\/h1>/)
 	assert.match(pageHtml, /华电邮箱/)
 })
 
-test('heading decorations preserve the trailing anchor required by local search', async () => {
+test('heading decorations preserve the trailing anchor', async () => {
 	const md = await renderer
 	const html = await md.renderAsync('## 知识技能掌握\n\n正文')
 	assert.match(html, /<h2[^>]*><span class="heading-wordmark" aria-hidden="true"><\/span>知识技能掌握\s*<a[^>]+href="#知识技能掌握"[^>]*>.*?<\/a><\/h2>/)
 })
 
-test('custom search rendering respects search false', async () => {
-	const md = await renderer
-	assert.equal(await render('---\nsearch: false\n---\n# 不索引\n\n正文', { relativePath: 'hidden.md', path: join(docsRoot, 'hidden.md'), cleanUrls: true }, md), '')
-})
-
-test('Chinese tokenization matches email independently of its campus prefix', () => {
-	const tokenize = search.options!.miniSearch!.options!.tokenize!
-	assert.ok(tokenize('华电邮箱').includes('邮箱'))
-	assert.deepEqual(tokenize('邮箱'), ['邮箱'])
-	assert.ok(tokenize('华北电力大学电子邮箱').includes('邮箱'))
-	assert.ok(tokenize('VPN 与 GitHub').includes('GitHub'))
+test('search index stores whole article text and skips empty placeholders', async () => {
+	const articles = scanArticles().filter(article => [
+		'05.校园生活/01.常用账号与默认密码.md',
+		'02.学习专题/03.等级、资格考试专题/01.四六级.md',
+	].includes(article.source))
+	const outDir = mkdtempSync(join(tmpdir(), 'wiki-search-'))
+	try {
+		await writeSearchIndex({ articles, docsRoot, outDir, markdown: config.markdown! })
+		const records = JSON.parse(readFileSync(join(outDir, 'search-index.json'), 'utf8')) as { route: string, text: string }[]
+		assert.equal(records.length, 1)
+		assert.equal(records[0].route, '/pages/accountpassword')
+		assert.ok(records[0].text.includes('华电邮箱'))
+	}
+	finally {
+		rmSync(outDir, { recursive: true, force: true })
+	}
 })


### PR DESCRIPTION
## 概述

将 Wiki 搜索从 VitePress 自带 MiniSearch 换成项目自研的**整串匹配本地搜索**：

- 构建时把每篇文章渲染为纯文本，生成 `dist/search-index.json`（不依赖任何第三方搜索服务）。
- 不做中文分词，查询内容必须作为一段连续文字出现在页面里才算命中。
- 新增自定义导航搜索组件 `WikiSearch.vue`，支持 Ctrl/Cmd+K、方向键选择、Enter 打开。
- 点击搜索结果后跳转到文章正文中该段文字第一次出现的位置，并短暂高亮。

## 主要改动

- `docs/.vitepress/search-index.ts`：构建期生成全文搜索索引
- `docs/.vitepress/theme/components/WikiSearch.vue`：搜索弹窗与首处命中跳转
- `docs/.vitepress/config.mts`：替换默认搜索组件、`buildEnd` 生成索引
- `tests/search.test.ts`：更新为验证隐藏标题与索引内容

## 验证

- `pnpm check`（类型检查 + lint + 9 项测试）全部通过
- 实测：`华电邮箱` 只命中“常用账号与默认密码”，并可跳转到表格中对应位置高亮