### PR TITLE
feat: cardlist 支持卡片/紧凑小卡/列表三种排列方式

### DIFF
--- a/docs/.vitepress/cardlist.ts
+++ b/docs/.vitepress/cardlist.ts
@@ -14,6 +14,14 @@ export function cardlist(md: MarkdownRenderer) {
 			return false
 		if (silent)
 			return true
+		// 页面级排列切换条：只在每篇 Markdown 的第一个 cardlist 前插入一次，
+		// 切换结果作用于整页所有卡片区块（由主题脚本写入 html[data-wiki-cardlist-layout]）。
+		const toolbar = `<div class="cardlist-layout-toolbar" role="group" aria-label="卡片排列方式">
+			<span class="cardlist-layout-label">排列方式</span>
+			<button type="button" data-wiki-cardlist-layout="cards">卡片</button>
+			<button type="button" data-wiki-cardlist-layout="compact">紧凑小卡</button>
+			<button type="button" data-wiki-cardlist-layout="table">列表</button>
+		</div>`
 		const tokens = md.parse(state.getLines(start + 1, close, state.blkIndent, false), state.env)
 		const html: string[] = []
 		let headers: string[] = []
@@ -26,6 +34,10 @@ export function cardlist(md: MarkdownRenderer) {
 				case 'table_open':
 					inTable = true
 					headers = []
+					if (!state.env.cardlistLayoutToolbar) {
+						state.env.cardlistLayoutToolbar = true
+						html.push(toolbar)
+					}
 					html.push('<div class="campus-card-grid" role="list">')
 					break
 				case 'table_close':

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -15,6 +15,39 @@ import WikiLayout from './components/WikiLayout.vue'
 import '@vitepress-plugin/markmap/style.css'
 import './styles/index.css'
 
+const CARD_LAYOUT_KEY = 'ncepu-wiki:cardlist-layout'
+const CARD_LAYOUT_VALUES = ['cards', 'compact', 'table'] as const
+type CardLayout = typeof CARD_LAYOUT_VALUES[number]
+
+function isCardLayout(value: string | null | undefined): value is CardLayout {
+	return typeof value === 'string' && (CARD_LAYOUT_VALUES as readonly string[]).includes(value)
+}
+
+/** 未主动选择时：手机默认紧凑小卡，桌面保持原有卡片。 */
+function defaultCardLayout(): CardLayout {
+	return window.matchMedia('(max-width: 640px)').matches ? 'compact' : 'cards'
+}
+
+function readCardLayout(): CardLayout {
+	const saved = localStorage.getItem(CARD_LAYOUT_KEY)
+	return isCardLayout(saved) ? saved : defaultCardLayout()
+}
+
+function applyCardLayout(layout: CardLayout) {
+	document.documentElement.dataset.wikiCardlistLayout = layout
+}
+
+function syncCardLayout() {
+	if (typeof window === 'undefined' || typeof document === 'undefined')
+		return
+	try {
+		applyCardLayout(readCardLayout())
+	}
+	catch {
+		applyCardLayout(defaultCardLayout())
+	}
+}
+
 export default {
 	extends: DefaultTheme,
 	Layout: WikiLayout,
@@ -31,10 +64,37 @@ export default {
 		app.component('ArticleIndex', ArticleIndex)
 		app.component('DownloadPageImage', DownloadPageImage)
 		router.onAfterRouteChange = () => {
-			if (typeof window !== 'undefined')
+			if (typeof window !== 'undefined') {
 				window.dispatchEvent(new Event('wiki:route-change'))
+				syncCardLayout()
+			}
 		}
 		if (typeof document !== 'undefined') {
+			syncCardLayout()
+			const cardMobileQuery = window.matchMedia('(max-width: 640px)')
+			cardMobileQuery.addEventListener('change', () => {
+				// 仅在用户没有主动选择时跟随默认布局（手机/桌面）
+				if (!localStorage.getItem(CARD_LAYOUT_KEY))
+					syncCardLayout()
+			})
+			document.addEventListener('click', (event) => {
+				const target = event.target
+				if (!(target instanceof Element))
+					return
+				const button = target.closest<HTMLButtonElement>('button[data-wiki-cardlist-layout]')
+				if (!button)
+					return
+				const layout = button.dataset.wikiCardlistLayout
+				if (isCardLayout(layout)) {
+					try {
+						localStorage.setItem(CARD_LAYOUT_KEY, layout)
+					}
+					catch {
+						// 隐私模式等场景下无法持久化也不影响本次切换
+					}
+					applyCardLayout(layout)
+				}
+			})
 			document.addEventListener('click', (event) => {
 				const target = event.target
 				if (!(target instanceof Element))

--- a/docs/.vitepress/theme/styles/cards.css
+++ b/docs/.vitepress/theme/styles/cards.css
@@ -441,3 +441,197 @@
 .VPSidebarItem.level-3 > .item::before {
 	content: counter(sidebar, lower-roman) / "";
 }
+
+/* ---- cardlist 排列方式切换条 ---- */
+.cardlist-layout-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	margin: 0.25rem 0 0.75rem;
+	font-size: 0.75rem;
+	color: var(--vp-c-text-2);
+}
+
+.cardlist-layout-toolbar .cardlist-layout-label {
+	margin-right: 2px;
+}
+
+.cardlist-layout-toolbar button {
+	padding: 0.2rem 0.7rem;
+	border: 1px solid var(--vp-c-divider);
+	border-radius: 999px;
+	background: transparent;
+	font-size: 0.78rem;
+	color: inherit;
+	transition: border-color 0.2s, color 0.2s, background 0.2s;
+	cursor: pointer;
+}
+
+.cardlist-layout-toolbar button:hover {
+	border-color: var(--vp-c-brand-1);
+	color: var(--vp-c-brand-1);
+}
+
+html[data-wiki-cardlist-layout="cards"] .cardlist-layout-toolbar button[data-wiki-cardlist-layout="cards"],
+html[data-wiki-cardlist-layout="compact"] .cardlist-layout-toolbar button[data-wiki-cardlist-layout="compact"],
+html[data-wiki-cardlist-layout="table"] .cardlist-layout-toolbar button[data-wiki-cardlist-layout="table"] {
+	border-color: var(--vp-c-brand-1);
+	background: var(--vp-c-brand-soft);
+	font-weight: 600;
+	color: var(--vp-c-brand-1);
+}
+
+/* ---- 紧凑小卡：多列、去头像/装饰，突出群号或评分 ---- */
+html[data-wiki-cardlist-layout="compact"] .campus-card-grid {
+	grid-template-columns: repeat(auto-fill, minmax(min(100%, 8.5rem), 1fr));
+	gap: 0.5rem;
+	margin-top: 0.5rem;
+}
+
+html[data-wiki-cardlist-layout="compact"] .campus-card-grid .campus-card {
+	flex-direction: column;
+	gap: 0.2rem;
+	padding: 0.55rem 0.4rem;
+}
+
+html[data-wiki-cardlist-layout="compact"] .group-avatar,
+html[data-wiki-cardlist-layout="compact"] .card-blur,
+html[data-wiki-cardlist-layout="compact"] .campus-card-field,
+html[data-wiki-cardlist-layout="compact"] .card-join {
+	display: none;
+}
+
+html[data-wiki-cardlist-layout="compact"] .vp-doc .campus-card-title {
+	margin-top: 0.15rem;
+	font-size: 0.82rem;
+	line-height: 1.35;
+}
+
+html[data-wiki-cardlist-layout="compact"] .group-contact {
+	justify-content: center;
+	font-size: 0.78rem;
+	line-height: 1.4;
+}
+
+html[data-wiki-cardlist-layout="compact"] .card-badges {
+	margin-top: 0;
+	padding: 0 6px;
+	font-size: 0.65rem;
+	line-height: 1.5;
+}
+
+html[data-wiki-cardlist-layout="compact"] .card-description {
+	display: -webkit-box;
+	overflow: hidden;
+	font-size: 0.72rem;
+	-webkit-line-clamp: 2;
+	line-height: 1.45;
+	-webkit-box-orient: vertical;
+}
+
+html[data-wiki-cardlist-layout="compact"] .food-scores {
+	gap: 0.4rem;
+	font-size: 0.7rem;
+}
+
+/* ---- 列表：每条数据一行，去掉卡片背景与头像 ---- */
+html[data-wiki-cardlist-layout="table"] .campus-card-grid {
+	display: block;
+	margin-top: 0.5rem;
+}
+
+html[data-wiki-cardlist-layout="table"] .campus-card-grid .campus-card {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.2rem 0.75rem;
+	width: 100%;
+	margin: 0;
+	padding: 0.35rem 0.6rem;
+	border: 0;
+	border-bottom: 1px solid var(--vp-c-divider);
+	border-radius: 0;
+	background: transparent;
+	text-align: start;
+}
+
+html[data-wiki-cardlist-layout="table"] .campus-card + .campus-card {
+	margin-top: 0;
+}
+
+html[data-wiki-cardlist-layout="table"] .campus-card:last-child {
+	border-bottom: 0;
+}
+
+html[data-wiki-cardlist-layout="table"] .group-avatar,
+html[data-wiki-cardlist-layout="table"] .card-blur,
+html[data-wiki-cardlist-layout="table"] .card-join,
+html[data-wiki-cardlist-layout="table"] .food-card-icon {
+	display: none;
+}
+
+html[data-wiki-cardlist-layout="table"] .vp-doc .campus-card-title {
+	flex: 1 1 9rem;
+	margin: 0;
+	font-size: 0.92rem;
+	line-height: 1.45;
+}
+
+html[data-wiki-cardlist-layout="table"] .group-contact {
+	justify-content: flex-start;
+	font-size: 0.85rem;
+}
+
+html[data-wiki-cardlist-layout="table"] .card-badges {
+	margin: 0 0 0 auto;
+}
+
+html[data-wiki-cardlist-layout="table"] .food-scores {
+	margin-left: auto;
+	font-size: 0.75rem;
+}
+
+html[data-wiki-cardlist-layout="table"] .campus-card-field {
+	display: flex;
+	flex-basis: 100%;
+	flex-wrap: wrap;
+	gap: 0.2rem 0.5rem;
+	margin-top: 0.15rem;
+	font-size: 0.8rem;
+	line-height: 1.55;
+}
+
+html[data-wiki-cardlist-layout="table"] .campus-card-label {
+	flex: 0 0 auto;
+	min-width: 4.5rem;
+	margin: 0;
+	font-size: 0.7rem;
+	color: var(--vp-c-text-3);
+}
+
+html[data-wiki-cardlist-layout="table"] .card-description {
+	flex-basis: 100%;
+	font-size: 0.8rem;
+	line-height: 1.55;
+}
+
+/* 手机端 JS 尚未写入选择前的默认展示：直接先按紧凑小卡渲染，避免先撑开再收缩 */
+@media (max-width: 640px) {
+	html:not([data-wiki-cardlist-layout]) .campus-card-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.5rem;
+	}
+
+	html:not([data-wiki-cardlist-layout]) .group-avatar,
+	html:not([data-wiki-cardlist-layout]) .card-blur,
+	html:not([data-wiki-cardlist-layout]) .campus-card-field,
+	html:not([data-wiki-cardlist-layout]) .card-join {
+		display: none;
+	}
+
+	html:not([data-wiki-cardlist-layout]) .group-cards .campus-card {
+		padding: 0.5rem 0.35rem;
+	}
+}

--- a/tests/cardlist.test.ts
+++ b/tests/cardlist.test.ts
@@ -11,6 +11,7 @@ test('card lists preserve rich cells, omit empty fields, and leave ordinary tabl
 	const table = '| 名称 | 加入方式 | 备注 |\n| --- | --- | --- |\n| A & B | [12345](https://example.com) | |'
 	const html = md.render(`::: cardlist\n\n${table}\n\n:::\n\n${table}`)
 	assert.equal((html.match(/class="campus-card"/g) || []).length, 1)
+	assert.equal((html.match(/class="cardlist-layout-toolbar"/g) || []).length, 1)
 	assert.match(html, /A &amp; B/)
 	assert.match(html, /href="https:\/\/example.com"/)
 	assert.doesNotMatch(html, /campus-card-label">备注/)


### PR DESCRIPTION
## 概述

为 cardlist 页面增加“排列方式”切换，解决长列表（如同好群 200+ 行）在手机/桌面浏览时过长的问题。

- 页面列表前新增切换条：**卡片 / 紧凑小卡 / 列表**
- 桌面端默认维持原有卡片布局
- 手机端（≤640px）默认紧凑小卡
- 用户选择写入 localStorage，跨页面访问时保留
- 三种模式均可随时互相切换，无需改 Markdown 数据

## 主要改动

- `docs/.vitepress/cardlist.ts`：每个页面只在第一个 cardlist 前插入一次切换条
- `docs/.vitepress/theme/index.ts`：读取/持久化排列方式，按设备宽度决定默认值
- `docs/.vitepress/theme/styles/cards.css`：紧凑小卡、列表两种布局样式及切换条样式
- `tests/cardlist.test.ts`：补充切换条只出现一次的测试

## 验证

- `pnpm check`（类型检查 + lint + 9 项测试）全部通过
- 实测同好群（223 行）：手机端紧凑小卡两列展示，列表模式每行一条，均明显减少滚动长度